### PR TITLE
RFC-2228: job_container support for shared storage

### DIFF
--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -47,3 +47,4 @@ role_slurm_conf_debug_flags: ''
 role_slurm_reboot_program: /usr/sbin/reboot
 role_slurm_maria_upstream: false
 role_slurm_job_container_base_path:
+role_slurm_job_container_shared_storage: false

--- a/roles/slurm/molecule/centos7/molecule.yml
+++ b/roles/slurm/molecule/centos7/molecule.yml
@@ -42,6 +42,8 @@ platforms:
     children:
       - cluster_compute1
     command: /sbin/init
+    security_opts:
+      - apparmor:unconfined
     tmpfs:
       - /tmp
       - /run
@@ -60,6 +62,8 @@ platforms:
     children:
       - cluster_compute2
     command: /sbin/init
+    security_opts:
+      - apparmor:unconfined
     tmpfs:
       - /tmp
       - /run

--- a/roles/slurm/molecule/resources/playbooks/converge.yml
+++ b/roles/slurm/molecule/resources/playbooks/converge.yml
@@ -3,6 +3,7 @@
   hosts: all
   tasks:
     - name: Include slurm role
+      #tags: reconfigure
       include_role:
         name: slurm
       vars:
@@ -55,3 +56,5 @@
         role_slurm_configless_dns: false
         role_slurm_db_replication_pw: replicationpw
         role_slurm_db_upstream: "{{ ansible_distribution_major_version == '7' }}"
+        role_slurm_job_container_base_path: /mnt
+        role_slurm_job_container_shared_storage: true

--- a/roles/slurm/molecule/resources/tests/test_compute.py
+++ b/roles/slurm/molecule/resources/tests/test_compute.py
@@ -28,6 +28,12 @@ def test_no_slurm_configs(host):
     assert not host.file('/etc/slurm/').exists
 
 
+def test_job_container_dir_exists(host):
+    hostname = host.check_output('hostname -s')
+    assert host.file(f'/mnt/{hostname}').exists
+    assert host.file(f'/mnt/{hostname}').is_directory
+
+
 def test_munge_service_running(host):
     munge_service = host.service("munge")
     assert munge_service.is_enabled

--- a/roles/slurm/molecule/resources/tests/test_control.py
+++ b/roles/slurm/molecule/resources/tests/test_control.py
@@ -32,3 +32,7 @@ def test_slurmctld_service_running(host):
     slurmctld_service = host.service("slurmctld")
     assert slurmctld_service.is_enabled
     assert slurmctld_service.is_running
+
+
+def test_job_container_file(host):
+    assert host.file('/etc/slurm/job_container.conf').exists

--- a/roles/slurm/molecule/stream8/molecule.yml
+++ b/roles/slurm/molecule/stream8/molecule.yml
@@ -42,6 +42,8 @@ platforms:
     children:
       - cluster_compute1
     command: /sbin/init
+    security_opts:
+      - apparmor:unconfined
     tmpfs:
       - /tmp
       - /run
@@ -60,6 +62,8 @@ platforms:
     children:
       - cluster_compute2
     command: /sbin/init
+    security_opts:
+      - apparmor:unconfined
     tmpfs:
       - /tmp
       - /run

--- a/roles/slurm/templates/job_container.conf.j2
+++ b/roles/slurm/templates/job_container.conf.j2
@@ -1,8 +1,18 @@
-###
-# Sample job_container.conf file 2
-# Define 1 basepath that will be on all nodes and automatically created.
-###
-AutoBasePath=true
+# {{ ansible_managed }}
 {% if role_slurm_job_container_base_path %}
+{% if not role_slurm_job_container_shared_storage %}
+AutoBasePath=true
 BasePath={{ role_slurm_job_container_base_path }}
+{% else %}
+{% for part in role_slurm_partitions %}
+{% for group in part.get('groups', [part]) %}
+{% if (group.num_nodes | int) > 0  %}
+{% for ix in range(0, group.num_nodes | int) %}
+{% set nodename=group.cluster_name|default(role_slurm_node_prefix) +'-' + group.name + '-' + (ix | string) %}
+NodeName={{ nodename }} AutoBasePath=true BasePath={{ role_slurm_job_container_base_path }}/{{ nodename }}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% endif %}
 {% endif %}


### PR DESCRIPTION
Added a new variable role_slurm_job_container_shared_storage (default: false).
If set to true, it will assume that the BasePath for the job_container
is on a shared storage (i.e. BeeGFS) and create seperate folders
for each node using the hostname.