### PR TITLE
Add second goss check method

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: clip
 name: hpc
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.1.2
+version: 1.2.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/nhc/defaults/main.yml
+++ b/roles/nhc/defaults/main.yml
@@ -29,3 +29,6 @@ nhc_group_random_user: "role.cbe.users"
 nhc_timeout:
 
 nhc_watchdog_timeout:
+
+nhc_goss_execute: true
+nhc_goss_outputfile:

--- a/roles/nhc/templates/goss.nhc
+++ b/roles/nhc/templates/goss.nhc
@@ -11,3 +11,12 @@ function check_goss() {
 
   return ${GOSS_RESULT}
 }
+
+function check_goss_output() {
+
+  GOSS_FILE=$1
+  grep -Fxq 'goss_test_failed_count 0' ${GOSS_FILE}
+  GOSS_RESULT=$?
+
+  return ${GOSS_RESULT}
+}

--- a/roles/nhc/templates/nhc.conf.j2
+++ b/roles/nhc/templates/nhc.conf.j2
@@ -219,8 +219,12 @@
 ### More CLIP specific checks
 ###
 
+{% if (nhc_goss_execute | bool) == true %}
 # run Goss tests
     * || check_goss
+{% elif nhc_goss_outputfile %}
+    * || check_goss_output {{ nhc_goss_outputfile }}
+{% endif %}
 
 # check if sssd is properly resolving user ids
     * || check_id_from_group role.cbe.users


### PR DESCRIPTION
Add a second method to check the goss results by not running the goss
test expliclty but check the output of the goss test that was run by an
external program (i.e. for prometheus).

Add 2 variables to control which behavior is used and where the goss output file is located