### PR TITLE
RFC-2409: Upgrade SLURM to 22.05.5

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: clip
 name: hpc
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.7.0
+version: 1.8.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/slurm/molecule/resources/playbooks/prepare.yml
+++ b/roles/slurm/molecule/resources/playbooks/prepare.yml
@@ -3,7 +3,7 @@
 - name: Install SLURM package
   hosts: all
   vars:
-    role_slurm_version: 21.08.5-1.el{{ansible_distribution_major_version}}
+    role_slurm_version: 22.05.8-1.el{{ansible_distribution_major_version}}
   tasks:
     - name: Install epel-release and versionlock
       yum:

--- a/roles/slurm/tasks/runtime.yml
+++ b/roles/slurm/tasks/runtime.yml
@@ -143,7 +143,6 @@
   with_items:
     - slurm.conf.j2
     - cgroup.conf.j2
-    - cgroup_allowed_devices_file.conf.j2
     - gres.conf.j2
     - job_container.conf.j2
   notify:

--- a/roles/slurm/templates/cgroup_allowed_devices_file.conf.j2
+++ b/roles/slurm/templates/cgroup_allowed_devices_file.conf.j2
@@ -1,8 +1,0 @@
-# {{ ansible_managed }}
-/dev/null
-/dev/urandom
-/dev/zero
-/dev/sda*
-/dev/cpu/*/*
-/dev/pts/*
-# GPU not needed to be whitelisted according to: https://bugs.schedmd.com/show_bug.cgi?id=3480


### PR DESCRIPTION
Remove the cgroup_allowed_devices_file.conf.j2 file as it is deprecated