### PR TITLE
RFC-2420: Add support for unning goss as a systemd service

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: clip
 name: hpc
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.5.0
+version: 1.6.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/goss/README.md
+++ b/roles/goss/README.md
@@ -22,7 +22,7 @@ Role Variables
 _defaults/main.yml_
 
 ```
-goss_version: "0.3.11"
+goss_version: "0.3.20"
 goss_install_dir: "/usr/local/bin"
 goss_test_file: "dummy.yml"
 # if this is empty, no variable file will be created
@@ -54,7 +54,7 @@ An example playbook might look something like this:
   become: false
   gather_facts: true
   vars:
-    - goss_version: "0.3.11"
+    - goss_version: "0.3.20"
     - goss_install_dir: "/usr/local/bin"
     - goss_test_file: "compute.yml"
     - goss_template_vars:

--- a/roles/goss/defaults/main.yml
+++ b/roles/goss/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-goss_version: "0.3.11"
+goss_version: "0.3.20"
 goss_install_dir: "/usr/local/bin"
 goss_test_file: "dummy.yml"
 # if this is empty, no variable file will be created
@@ -7,5 +7,5 @@ goss_template_vars: ""
 goss_template_vars_file: "goss_vars.yml"
 goss_node_exporter_textfile_dir: "/tmp"
 goss_cron_schedule: "*/1 * * * *"
-
+goss_run_as_service: false
 # defaults file for role-goss

--- a/roles/goss/handlers/main.yml
+++ b/roles/goss/handlers/main.yml
@@ -1,2 +1,11 @@
 ---
 # handlers file for role-goss
+- name: restart goss
+  systemd:
+    daemon_reload: true
+    name: goss
+    state: restarted
+  when: goss_run_as_service
+  tags:
+    - always
+    - goss_reconfigure

--- a/roles/goss/molecule/default/converge.yml
+++ b/roles/goss/molecule/default/converge.yml
@@ -5,3 +5,5 @@
     - name: Include goss role
       include_role:
         name: "goss"
+      vars:
+        goss_run_as_service: True

--- a/roles/goss/molecule/default/molecule.yml
+++ b/roles/goss/molecule/default/molecule.yml
@@ -10,11 +10,31 @@ lint: |
   flake8
 platforms:
   - name: instance-centos7-${INSTANCE_ID:-local}
-    image: centos:7
+    image: centos/systemd:latest
     pre_build_image: true
+    command: /sbin/init
+    security_opts:
+      - apparmor:unconfined
+    tmpfs:
+      - /tmp
+      - /run
+    capabilities:
+      - SYS_ADMIN
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: instance-stream8-${INSTANCE_ID:-local}
     image: quay.io/centos/centos:stream8
     pre_build_image: true
+    command: /sbin/init
+    security_opts:
+      - apparmor:unconfined
+    tmpfs:
+      - /tmp
+      - /run
+    capabilities:
+      - SYS_ADMIN
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
 provisioner:
   name: ansible
 scenario:

--- a/roles/goss/molecule/default/tests/test_default.py
+++ b/roles/goss/molecule/default/tests/test_default.py
@@ -15,3 +15,9 @@ def test_hosts_file(host):
     assert f.exists
     assert f.user == 'root'
     assert f.group == 'root'
+
+
+def test_munge_service_running(host):
+    munge_service = host.service("goss")
+    assert munge_service.is_enabled
+    assert munge_service.is_running

--- a/roles/goss/tasks/main.yml
+++ b/roles/goss/tasks/main.yml
@@ -8,6 +8,7 @@
     url: "https://github.com/aelsabbahy/goss/releases/download/v{{ goss_version }}/goss-linux-amd64"
     dest: "/tmp/goss-linux-amd64"
   delegate_to: localhost
+  run_once: true
 
 - name: make sure goss_install_dir exists
   file:
@@ -50,6 +51,18 @@
     group: root
     mode: 0750
 
+
+- name: deploy goss check script
+  tags:
+    - always
+    - goss_reconfigure
+  template:
+    src: "templates/goss.j2"
+    dest: "{{ goss_install_dir }}/goss"
+    owner: root
+    group: root
+    mode: 0750
+
 - name: deploy goss test .yml file
   tags:
     - always
@@ -68,6 +81,30 @@
     dest: "{{ goss_install_dir }}/{{ goss_template_vars_file }}"
     mode: 0644
   when: goss_template_vars | default(False)
+
+
+- name: Deploy GOSS service file
+  template:
+    src: goss.service.j2
+    dest: /etc/systemd/system/goss.service
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart goss
+  tags:
+    - always
+    - goss_reconfigure
+
+- name: Ensure GOSS service is enabled on boot
+  systemd:
+    daemon_reload: true
+    name: goss
+    enabled: "{{ goss_run_as_service }}"
+    state: "{{ (goss_run_as_service ) | ternary('started', 'stopped') }}"
+  tags:
+    - always
+    - goss_reconfigure
+
 
 #
 # vim: sts=2:ai:list:cursorcolumn

--- a/roles/goss/templates/goss.j2
+++ b/roles/goss/templates/goss.j2
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+{{ ansible_managed | comment }}
+
+{{ goss_install_dir }}/goss-linux-amd64 --gossfile {{ goss_install_dir }}/{{ goss_test_file }} {% if goss_template_vars | default(False) %} --vars {{ goss_install_dir }}/{{ goss_template_vars_file }}{% endif %} validate --format tap

--- a/roles/goss/templates/goss.service.j2
+++ b/roles/goss/templates/goss.service.j2
@@ -1,0 +1,28 @@
+{{ ansible_managed | comment }}
+
+[Unit]
+Description=GOSS Node Exporter
+After=network-online.target
+
+[Service]
+Type=simple
+User=root
+Group=root
+ExecStart={{ goss_install_dir }}/goss-linux-amd64 \
+    --gossfile {{ goss_install_dir }}/{{ goss_test_file }} \
+{% if goss_template_vars | default(False) %}
+    --vars {{ goss_install_dir }}/{{ goss_template_vars_file }} \
+{% endif %}
+    serve --format prometheus
+
+SyslogIdentifier=goss
+Restart=always
+RestartSec=1
+StartLimitInterval=0
+ProtectHome=yes
+# cannot use because otherwise chronyc activity will fail due to selinux
+#NoNewPrivileges=yes
+ProtectSystem=full
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/goss/templates/prometheus_goss.cron.j2
+++ b/roles/goss/templates/prometheus_goss.cron.j2
@@ -1,1 +1,1 @@
-{{ goss_cron_schedule }} root {{ goss_install_dir }}/prometheus_goss.sh
+{% if goss_cron_schedule %}{{ goss_cron_schedule }} root {{ goss_install_dir }}/prometheus_goss.sh{%endif%}

--- a/roles/goss/templates/prometheus_goss.sh.j2
+++ b/roles/goss/templates/prometheus_goss.sh.j2
@@ -1,25 +1,8 @@
 #!/usr/bin/env bash
 
-GOSS_TMP_FILE={{ goss_node_exporter_textfile_dir }}/goss.out.$$
 PROM_TMP_FILE={{ goss_node_exporter_textfile_dir }}/goss.prom.$$
 PROM_OUT_FILE={{ goss_node_exporter_textfile_dir }}/goss.prom
 
-{{ goss_install_dir }}/goss-linux-amd64 --gossfile {{ goss_install_dir }}/{{ goss_test_file }} {% if goss_template_vars | default(False) %} --vars {{ goss_install_dir }}/{{ goss_template_vars_file }}{% endif %} validate --format nagios --no-color > $GOSS_TMP_FILE
+{{ goss_install_dir }}/goss-linux-amd64 --gossfile {{ goss_install_dir }}/{{ goss_test_file }} {% if goss_template_vars | default(False) %} --vars {{ goss_install_dir }}/{{ goss_template_vars_file }}{% endif %} validate --format prometheus --no-color > $PROM_TMP_FILE
 
-COUNT=$(sed -e 's/.*Count: \([0-9]\+\).*/\1/' $GOSS_TMP_FILE)
-printf "# HELP goss_test_count Number of tests that ran.\n" >> $PROM_TMP_FILE
-printf "# TYPE goss_test_count gauge\n" >> $PROM_TMP_FILE
-printf "goss_test_count %d\n" $COUNT >> $PROM_TMP_FILE
-
-FAILED=$(sed -e 's/.*Failed: \([0-9]\+\).*/\1/' $GOSS_TMP_FILE)
-printf "# HELP goss_test_failed_count Number of FAILED tests in the last run.\n" >> $PROM_TMP_FILE
-printf "# TYPE goss_test_failed_count gauge\n" >> $PROM_TMP_FILE
-printf "goss_test_failed_count %d\n" $FAILED >> $PROM_TMP_FILE
-
-SKIPPED=$(sed -e 's/.*Skipped: \([0-9]\+\).*/\1/' $GOSS_TMP_FILE)
-printf "# HELP goss_test_skipped_count Number of SKIPPED tests in the last run.\n" >> $PROM_TMP_FILE
-printf "# TYPE goss_test_skipped_count gauge\n" >> $PROM_TMP_FILE
-printf "goss_test_skipped_count %d\n" $SKIPPED >> $PROM_TMP_FILE
-
-rm $GOSS_TMP_FILE
 mv $PROM_TMP_FILE $PROM_OUT_FILE

--- a/roles/nhc/templates/goss.nhc
+++ b/roles/nhc/templates/goss.nhc
@@ -12,12 +12,21 @@ function check_goss() {
   return ${GOSS_RESULT}
 }
 
-function check_goss_output() {
+function check_goss_prom() {
+  GOSS_FILE=$1
+  PROM_TMP_FILE=${GOSS_FILE}.$$
+  /usr/local/bin/goss-linux-amd64 --gossfile /usr/local/bin/goss_compute.yml  --vars /usr/local/bin/goss_vars.yml validate --format prometheus > ${PROM_TMP_FILE}
+  mv $PROM_TMP_FILE $GOSS_FILE
+  check_goss_prom_output ${GOSS_FILE}
+  return $?
+}
+
+function check_goss_prom_output() {
 
   GOSS_FILE=$1
   if [ -s ${GOSS_FILE} ]
   then
-    grep -Fxq 'goss_test_failed_count 0' ${GOSS_FILE}
+    grep -Fxq 'goss_tests_run_outcomes_total{outcome="fail"} 0' ${GOSS_FILE}
     GOSS_RESULT=$?
   else
     GOSS_RESULT=0

--- a/roles/nhc/templates/nhc.conf.j2
+++ b/roles/nhc/templates/nhc.conf.j2
@@ -219,11 +219,15 @@
 ### More CLIP specific checks
 ###
 
-{% if (nhc_goss_execute | bool) == true %}
+{% if (nhc_goss_execute | bool) == true and nhc_goss_outputfile %}
 # run Goss tests
-    * || check_goss
-{% elif nhc_goss_outputfile %}
+    * || check_goss_prom  {{ nhc_goss_outputfile }}
+{% else %}
+{% if nhc_goss_outputfile %}
     * || check_goss_output {{ nhc_goss_outputfile }}
+{% else %}
+   * || check_goss
+{% endif %}
 {% endif %}
 
 # check if sssd is properly resolving user ids


### PR DESCRIPTION
The new goss binary supports native prometheus support. The goss role will now deploy the goss binary optionally as a systemd service.
Additonally change the goss.nhc script to support 3 methods of checking goss