### PR TITLE
RFC-2480: Add support for Slurm REST

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: clip
 name: hpc
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.8.1
+version: 1.9.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -61,3 +61,5 @@ role_slurm_power_save_exc_nodes:
 role_slurm_power_save_resume_program:
 role_slurm_power_save_suspend_program:
 role_slurm_dbd_conf_debug_flags: ''
+role_slurm_enable_rest: false
+role_slurm_auth_alt_parameters: "jwt_key=/etc/slurm/jwt.key"

--- a/roles/slurm/handlers/main.yml
+++ b/roles/slurm/handlers/main.yml
@@ -4,14 +4,16 @@
     name: "munge"
     state: restarted
   when: role_slurm_service_enabled | bool
+  tags: always
 
-- name: restart slurmdbd
+- name: Restart slurmdbd
   service:
     name: slurmdbd
     state: restarted
   delegate_to: "{{ role_slurm_db_host }}"
   run_once: true
   when: role_slurm_db_host in hostvars
+  tags: always
 
 - name: Restart slurmctld
   service:
@@ -21,6 +23,18 @@
   run_once: true
   when:
     - not (role_slurm_reconfigure | bool)
+  tags: always
+
+- name: Restart slurmrestd
+  systemd:
+    name: "slurmrestd"
+    daemon_reload: true
+    state: restarted
+  delegate_to: "{{ role_slurm_control_host }}"
+  run_once: true
+  when:
+    - not (role_slurm_reconfigure | bool)
+  tags: always
 
 - name: Restart SLURM service
   service:
@@ -30,6 +44,7 @@
     - role_slurm_service is not none
     - role_slurm_service_enabled | bool
     - not (role_slurm_reconfigure | bool)
+  tags: always
 
 - name: Restart mariadb service
   service:
@@ -37,9 +52,11 @@
     state: restarted
   delegate_to: "{{ role_slurm_db_host }}"
   run_once: true
+  tags: always
 
 - name: Reconfigure
   listen: "Restart SLURM service"
   run_once: true
   delegate_to: "{{ role_slurm_control_host }}"
   command: "/bin/scontrol reconfigure"
+  tags: always

--- a/roles/slurm/molecule/resources/playbooks/converge.yml
+++ b/roles/slurm/molecule/resources/playbooks/converge.yml
@@ -74,3 +74,5 @@
         role_slurm_dbd_purge_suspend: 1month
         role_slurm_dbd_purge_txn: 12month
         role_slurm_dbd_purge_usage: 24month
+        role_slurm_enable_rest: true
+        role_slurm_disable_token_creation: true

--- a/roles/slurm/molecule/resources/tests/test_rest.py
+++ b/roles/slurm/molecule/resources/tests/test_rest.py
@@ -1,0 +1,45 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import os
+import pytest
+import json
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('cluster_control')
+
+
+@pytest.mark.parametrize('pkg', [
+    "slurm-slurmrestd",
+])
+def test_pkgs(host, pkg):
+    package = host.package(pkg)
+    assert package.is_installed
+
+
+def test_munge_service_running(host):
+    munge_service = host.service("munge")
+    assert munge_service.is_enabled
+    assert munge_service.is_running
+
+
+def test_slurmrestd_service_running(host):
+    slurmrest_service = host.service("slurmrestd")
+    assert slurmrest_service.is_enabled
+    assert slurmrest_service.is_running
+
+
+def test_slurmrestd(host):
+    rest_url = "http://localhost:6820"
+    token = host.check_output("scontrol token lifespan=99999").split("=")[1]
+    header = f'-H "X-SLURM-USER-NAME:root" -H "X-SLURM-USER-TOKEN:{token}"'
+    ping_cmd = f'curl -s -X GET {header} {rest_url}/slurm/v0.0.37/ping'
+    jobs_cmd = f'curl -s -X GET {header} {rest_url}/slurmdb/v0.0.37/jobs'
+    ping = json.loads(host.check_output(f"bash -lc '{ping_cmd}'"))
+    assert len(ping['errors']) == 0
+    assert ping['pings'][0]['ping'] == 'UP'
+    jobs = json.loads(host.check_output(f"bash -lc '{jobs_cmd}'"))
+    assert len(jobs['errors']) == 0
+    assert len(jobs['jobs']) > 0

--- a/roles/slurm/tasks/db.yml
+++ b/roles/slurm/tasks/db.yml
@@ -69,7 +69,7 @@
     path: /etc/my.cnf
     mode: 0644
     section: mariadb
-    allow_no_value: true
+    allow_no_value: "{{ (item.option == 'log-bin') | ternary(true, false) }}"
     option: "{{ item.option }}"
     value: "{{ item.value | default(omit) }}"
   loop:
@@ -158,6 +158,8 @@
     state: directory
     path: "{{ role_slurm_dbd_archive_dir }}"
     owner: slurm
+    group: root
+    mode: 0750
   when: role_slurm_dbd_archive_dir is defined
 
 - name: template in slurmdbd.conf
@@ -169,4 +171,4 @@
     mode: 0600
     backup: true
   notify:
-    - restart slurmdbd
+    - Restart slurmdbd

--- a/roles/slurm/tasks/main.yml
+++ b/roles/slurm/tasks/main.yml
@@ -20,6 +20,12 @@
   delegate_to: "{{ role_slurm_control_host }}"
   run_once: true
 
+- include: rest.yml
+  when: role_slurm_enable_rest | bool
+  delegate_facts: true
+  delegate_to: "{{ role_slurm_control_host }}"
+  run_once: true
+
 - include: compute.yml
   when: role_slurm_enable.batch | bool
 

--- a/roles/slurm/tasks/rest.yml
+++ b/roles/slurm/tasks/rest.yml
@@ -1,0 +1,50 @@
+---
+- name: Install SLURM Rest packages
+  yum:
+    name:
+      - "slurm-slurmrestd"
+    state: installed
+  tags: rest
+
+- name: Create Slurm Rest Daemon user
+  ansible.builtin.user:
+    name: slurmrest
+    comment: SLURM REST daemon user
+    system: true
+    shell: /sbin/nologin
+  tags: rest
+
+- name: Create socket folder
+  file:
+    state: directory
+    path: /var/run/slurmrestd
+    owner: slurmrest
+    group: slurmrest
+    mode: "755"
+  tags: rest
+
+- name: Remove unix and port config from systemd
+  ini_file:
+    option: ExecStart
+    section: Service
+    value: "/usr/sbin/slurmrestd $SLURMRESTD_OPTIONS"
+    path: /usr/lib/systemd/system/slurmrestd.service
+    mode: "644"
+  notify: Restart slurmrestd
+  tags: rest
+
+- name: Copy /etc/default/slurmrestd
+  copy:
+    content: |
+      SLURMRESTD_OPTIONS="-u slurmrest -g slurmrest"
+      SLURMRESTD_LISTEN="unix:/var/run/slurmrestd/slurmrestd.socket,0.0.0.0:6820"
+    dest: /etc/default/slurmrestd
+    mode: "644"
+  notify: Restart slurmrestd
+  tags: rest
+
+- name: Ensure Slurmrest service is enabled
+  service:
+    name: "slurmrestd"
+    enabled: "true"
+  tags: rest

--- a/roles/slurm/tasks/runtime.yml
+++ b/roles/slurm/tasks/runtime.yml
@@ -56,6 +56,26 @@
   run_once: true
   when: role_slurm_munge_key is not defined
 
+- block:
+    - name: Generate a JWT key if not provided externally
+      command: "dd if=/dev/urandom of=/etc/slurm/jwt.key bs=32 count=1"
+      args:
+        creates: "/etc/slurm/jwt.key"
+      notify:
+        - Restart slurmctld
+        - Restart slurmrestd
+
+    - name: Fix JWT key permissions
+      file:
+        path: "/etc/slurm/jwt.key"
+        owner: slurm
+        group: slurm
+        mode: "0600"
+  delegate_to: "{{ role_slurm_control_host }}"
+  run_once: true
+  tags: rest
+  when: role_slurm_jwt_key is not defined and role_slurm_enable_rest
+
 
 - name: Copy external munge key if provided
   copy:
@@ -69,6 +89,22 @@
   when: role_slurm_munge_key is defined
   notify:
     - Restart Munge service
+
+- name: Copy external JWT key if provided
+  copy:
+    content: "{{ role_slurm_jwt_key | b64decode }}"
+    dest: "/etc/slurm/jwt.key"
+    owner: slurm
+    group: slurm
+    mode: "0600"
+  when: role_slurm_jwt_key is defined and role_slurm_enable_rest
+  delegate_to: "{{ role_slurm_control_host }}"
+  run_once: true
+  tags: rest
+  notify:
+    - Restart slurmctld
+    - Restart slurmrestd
+    - Restart slurmdbd
 
 - name: Make sure that Munge is running on control host
   service:
@@ -95,6 +131,32 @@
   notify:
     - Restart Munge service
 
+- name: Retrieve JWT key from Slurm control host
+  slurp:
+    src: "/etc/slurm/jwt.key"
+  register: slurm_jwt_key
+  delegate_to: "{{ role_slurm_control_host }}"
+  run_once: true
+  when: role_slurm_enable_rest
+  tags: rest
+
+
+- name: Write JWT key
+  copy:
+    content: "{{ slurm_jwt_key['content'] | b64decode }}"
+    dest: "/etc/slurm/jwt.key"
+    owner: slurm
+    group: slurm
+    mode: "0400"
+  delegate_to: "{{ role_slurm_db_host }}"
+  run_once: true
+  notify:
+    - Restart slurmctld
+    - Restart slurmrestd
+    - Restart slurmdbd
+  when: role_slurm_enable_rest
+  tags: rest
+
 - name: add slurm log dir
   file:
     path: /var/log/slurm
@@ -111,7 +173,7 @@
   delegate_to: "{{ role_slurm_db_host }}"
   run_once: true
   notify:
-    - restart slurmdbd
+    - Restart slurmdbd
 
 - name: Ensure Slurm services are enabled
   service:

--- a/roles/slurm/templates/slurm.conf.j2
+++ b/roles/slurm/templates/slurm.conf.j2
@@ -20,6 +20,10 @@ SlurmctldPort=6817
 SlurmdPort=6818
 SlurmctldParameters=enable_configless,idle_on_node_suspend
 AuthType=auth/munge
+{% if role_slurm_enable_rest %}
+AuthAltTypes=auth/jwt
+AuthAltParameters={{ role_slurm_auth_alt_parameters }}
+{% endif %}
 #JobCredentialPrivateKey=
 #JobCredentialPublicCertificate=
 StateSaveLocation=/var/spool/slurm

--- a/roles/slurm/templates/slurmdbd.conf.j2
+++ b/roles/slurm/templates/slurmdbd.conf.j2
@@ -57,7 +57,10 @@ PurgeUsageAfter={{ role_slurm_dbd_purge_usage }}
 # Authentication info
 AuthType=auth/munge
 #AuthInfo=/var/run/munge/munge.socket.2
-
+{% if role_slurm_enable_rest %}
+AuthAltTypes=auth/jwt
+AuthAltParameters={{ role_slurm_auth_alt_parameters }}
+{% endif %}
 
 # SlurmDBD info
 DbdHost={{ role_slurm_db_host }}


### PR DESCRIPTION
Add variable to enable SLURM Rest on the controller. Will use the specified JWT key or create a new one if not specified. Added molecule test for the SLURM Rest function