### PR TITLE
RFC-2565: Remove hardcoded role.cbe.users

### DIFF
--- a/roles/nhc/defaults/main.yml
+++ b/roles/nhc/defaults/main.yml
@@ -12,7 +12,7 @@ nhc_fs_mount_check: []
 nhc_fs_mount_default_opts: /(^|,)vers=3(,|$)/
 
 # sssd check which group to pick random user from
-nhc_group_random_user: role.cbe.users
+nhc_group_random_user:
 
 ## these hw checks are no longer run
 # nhc_hw_swap_free: 0

--- a/roles/nhc/templates/nhc.conf.j2
+++ b/roles/nhc/templates/nhc.conf.j2
@@ -230,8 +230,10 @@
 {% endif %}
 {% endif %}
 
+{% if nhc_group_random_user | length > 0 %}
 # check if sssd is properly resolving user ids
-    * || check_id_from_group role.cbe.users
+    * || check_id_from_group {{ nhc_group_random_user }}
+{% endif %}
 
 # nVidia HealthMon GPU health checks (requires Tesla Development Kit)
 #   * || check_nv_healthmon


### PR DESCRIPTION
Enable check only if nhc_group_random_user variable is set