### PR TITLE
Bugfix: The new NVIDIA GPUs (A100) have 2 flags that require the node…

### DIFF
--- a/roles/nhc/templates/nhc.conf.j2
+++ b/roles/nhc/templates/nhc.conf.j2
@@ -242,8 +242,8 @@
 # nVidia-smi GPU health checks (requires Tesla Development Kit)
    *-g*-* || check_nvsmi_healthmon
 
-# check for page retirement errors that require GPU device re-init
-   *-g*-* || check_nvidia_smi_page_retirement
+# check for pending remapped rows that require the GPU to be reset
+   *-g*-* || check_nvidia_smi_remapping_pending
 
-# check for uncorrectable remapped rows that require the GPU to be replaced
-   *-g*-* || check_nvidia_smi_remapped_rows
+# check for remapping failures that require the GPU to be replaced
+   *-g*-* || check_nvidia_smi_remapping_failure

--- a/roles/nhc/templates/nvidia_smi_remapped_rows.nhc
+++ b/roles/nhc/templates/nvidia_smi_remapped_rows.nhc
@@ -1,6 +1,7 @@
 # NHC check for testing nvidia uncorrectable remapped rows
-# check if there are uncorrectable remapped rows
-# If the threshold is above a certain number the GPU needs to be replaced:
+# 2 checks are implemented:
+# 1. check_nvidia_smi_remapping_pending: Check if there are pending remapping rows. If this is the case the GPU needs to be reset
+# 2. check_nvidia_smi_remapping_failure: If this flag is set, the GPU needs to be replaced
 # see: https://support.lenovo.com/us/en/solutions/ht513682-nvidia-a100-gpu-reports-ecc-errors-lenovo-thinkagile-and-thinksystem
 #  example:
 # GPU 00000000:00:08.0
@@ -16,10 +17,21 @@
 #            Low                           : 0 bank(s)
 #            None                          : 1 bank(s)
 
-function check_nvidia_smi_remapped_rows() {
+function check_nvidia_smi_remapping_pending() {
 
-  REMAPPED_DATA=$(nvidia-smi --query-remapped-rows=remapped_rows.uncorrectable --format=noheader,csv | grep -v 0 | grep -v '[N/A]')
-  if [ -n "$DEBUG" ]; then echo "uncorrectable remapped rows:"; echo $REMAPPED_DATA ; fi
+  REMAPPED_DATA=$(nvidia-smi --query-remapped-rows=remapped_rows.pending --format=noheader,csv | grep -v 0 | grep -v '[N/A]')
+  if [ -n "$DEBUG" ]; then echo "pending row-remappings (reset GPU to fix):"; echo $REMAPPED_DATA ; fi
+  if [ -z "$REMAPPED_DATA" ];
+  then
+    return 0
+  fi
+  return 1
+}
+
+function check_nvidia_smi_remapping_failure() {
+
+  REMAPPED_DATA=$(nvidia-smi --query-remapped-rows=remapped_rows.failure --format=noheader,csv | grep -v 0 | grep -v '[N/A]')
+  if [ -n "$DEBUG" ]; then echo "row-remapping failure (RMA GPU):"; echo $REMAPPED_DATA ; fi
   if [ -z "$REMAPPED_DATA" ];
   then
     return 0


### PR DESCRIPTION
… to be drained

1.) pending row remappings
2.) remapping failures

Use those instead of the uncorrectable value