### PR TITLE
Add support for NUMA configuration for latest Intel and AMD CPUs

### DIFF
--- a/extensions/molecule/slurm/playbooks/prepare.yml
+++ b/extensions/molecule/slurm/playbooks/prepare.yml
@@ -18,6 +18,7 @@
           - epel-release
           - hostname
           - python3-dnf-plugin-versionlock
+          - python-unversioned-command
           - openssh-server
           - sudo
           - net-tools

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: clip
 name: hpc
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.2.0
+version: 3.3.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/slurm/defaults/main.yml
+++ b/roles/slurm/defaults/main.yml
@@ -91,8 +91,10 @@ slurm_dbd_conf_debug_flags: ""
 slurm_db_data_dir:
 slurm_db_root_password: "{{ slurm_db_password }}"
 
-# Auto detection
-slurm_ram_multiplier: 0.95
+# ratio of the node's total memory that should be reserved for the system
+# and not included in the memory available for scheduling. Value is a percentage (1 = 100%).
+# Default is 0 (no memory reserved).
+slurm_mem_spec_percent: 0
 
 slurm_power_save: false
 

--- a/roles/slurm/files/slurmd_topology.fact
+++ b/roles/slurm/files/slurmd_topology.fact
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+"""Ansible local facts: gather Slurm node hardware topology via ``slurmd -C``.
+
+Runs ``slurmd -C --parameters=numa_node_as_socket`` and exposes the parsed
+key/value pairs as Ansible local facts under ``ansible_local.slurmd_topology``.
+
+When ``numa_node_as_socket`` is active, ``SocketsPerBoard`` reflects the number
+of NUMA nodes (rather than physical sockets), which is what Slurm uses for
+resource accounting.  The template falls back to standard Ansible facts when
+this script returns an empty dict (e.g. before slurmd is installed).
+"""
+
+import json
+import subprocess
+import sys
+
+SLURMD_BIN = "/usr/sbin/slurmd"
+
+# Keys whose values should be coerced to integers
+INT_KEYS = frozenset(
+    {"CPUs", "Boards", "SocketsPerBoard", "CoresPerSocket", "ThreadsPerCore", "RealMemory"}
+)
+
+
+def main() -> None:
+    try:
+        result = subprocess.run(
+            [SLURMD_BIN, "-C", "--parameters=numa_node_as_socket"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        # slurmd is not installed yet – return empty facts so the template can
+        # fall back to standard Ansible facts.
+        print(json.dumps({}))
+        sys.exit(0)
+    except Exception as exc:  # noqa: BLE001
+        print(json.dumps({"error": str(exc)}))
+        sys.exit(0)
+
+    if result.returncode != 0:
+        print(json.dumps({"error": (result.stderr or result.stdout).strip()}))
+        sys.exit(0)
+
+    facts: dict = {}
+    for line in result.stdout.splitlines():
+        # The first line begins with NodeName= and contains all hardware tokens.
+        if line.startswith("NodeName="):
+            for token in line.split():
+                if "=" in token:
+                    key, _, value = token.partition("=")
+                    if key in INT_KEYS:
+                        try:
+                            value = int(value)  # type: ignore[assignment]
+                        except ValueError:
+                            pass
+                    facts[key] = value
+            break  # Only the first line carries hardware details
+
+    print(json.dumps(facts))
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/slurm/tasks/install.yml
+++ b/roles/slurm/tasks/install.yml
@@ -36,3 +36,32 @@
   tags: install
   ansible.builtin.dnf:
     name: "{{ slurm_packages }}"
+
+- name: install | Create facts directory
+  tags: install
+  when: slurm_enable.slurmd | bool
+  ansible.builtin.file:
+    path: /etc/ansible/facts.d/
+    state: directory
+    owner: root
+    group: root
+    mode: ugo=rwX
+
+- name: install | Deploy slurmd topology facts script
+  tags: install
+  when: slurm_enable.slurmd | bool
+  ansible.builtin.copy:
+    src: slurmd_topology.fact
+    dest: /etc/ansible/facts.d/slurmd_topology.fact
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: install | Refresh local Ansible facts on slurmd nodes
+  tags: install
+  when: slurm_enable.slurmd | bool
+  ansible.builtin.setup:
+    gather_subset:
+      - "!all"
+      - "!min"
+      - local

--- a/roles/slurm/templates/slurm.conf.j2
+++ b/roles/slurm/templates/slurm.conf.j2
@@ -10,7 +10,7 @@ ClusterName={{ slurm_cluster_name }}
 {%  endif %}
 {% endfor %}
 
-{% set jobsubmitplugins = ((['lua'] if slurm_job_submit_script | default('', true) | length > 0 else [])) + (slurm_config.get('JobSubmitPlugins', []) | unique) %}
+{% set jobsubmitplugins = ((['lua'] if slurm_job_submit_script | default('', true) | length > 0 else []) + slurm_config.get('JobSubmitPlugins', [])) | unique %}
 {% if jobsubmitplugins | length > 0 %}
 JobSubmitPlugins={{ jobsubmitplugins | join(',') }}
 {% endif %}
@@ -31,17 +31,33 @@ NodeName={{ node }}
 {%  set inventory_group_hosts = groups.get(inventory_group_name, []) %}
 {%      if inventory_group_hosts | length > 0 %}
 {%          set play_group_hosts = inventory_group_hosts | intersect (ansible_play_batch) %}
-{%          set first_host = play_group_hosts | first | mandatory('Inventory group "' ~ inventory_group_name ~ '" contains no hosts in this play - was --limit used?') %}
+{%          set _guard = play_group_hosts | first | mandatory('Inventory group "' ~ inventory_group_name ~ '" contains no hosts in this play - was --limit used?') %}
+{%          set ns = namespace(first_host=_guard, found_topo=false) %}
+{%          for h in play_group_hosts %}
+{%            if not ns.found_topo %}
+{%              set _topo = hostvars[h].get('ansible_facts', {}).get('ansible_local', {}).get('slurmd_topology', {}) %}
+{%              if _topo is mapping and _topo | length > 0 %}
+{%                set ns.first_host = h %}
+{%                set ns.found_topo = true %}
+{%              endif %}
+{%            endif %}
+{%          endfor %}
+{%          set first_host = ns.first_host %}
 {%          set first_host_hv = hostvars[first_host] %}
-{%          set ram_mb = (first_host_hv['ansible_facts']['memory_mb']['real']['total'] * (nodegroup.ram_multiplier | default(slurm_ram_multiplier))) | int %}
+{%          set slurmd_topo = first_host_hv.get('ansible_facts', {}).get('ansible_local', {}).get('slurmd_topology', {}) %}
+{%          set slurmd_topo = slurmd_topo if slurmd_topo is mapping else {} %}{# guard: fact may be a raw string if the interpreter was missing on a previous run #}
+{%          set ram_mb = slurmd_topo.get('RealMemory', first_host_hv['ansible_facts']['memory_mb']['real']['total']) | int %}
+{%          set mem_spec_limit = (ram_mb * nodegroup.get('mem_spec_percent', slurm_mem_spec_percent | default(0))) | int %}
 {%          set hostlists = (inventory_group_hosts | clip.hpc.hostlist_expression) %}{# hosts in inventory group aren't necessarily a single hostlist expression #}
+# Node config source ({{ first_host }}): {{ slurmd_topo | ternary('slurmd_topology facts', 'fallback to ansible_facts') }}
 NodeName={{ hostlists | join(',') }} {{ '' -}}
     Features={{ (['nodegroup_' ~ nodegroup.name] + nodegroup.features | default([]) ) | join(',') }} {{ '' -}}
     State=UNKNOWN {{ '' -}}
     RealMemory={{ nodegroup.ram_mb | default(ram_mb) }} {{ '' -}}
-    Sockets={{ first_host_hv['ansible_facts']['processor_count'] }} {{ '' -}}
-    CoresPerSocket={{ first_host_hv['ansible_facts']['processor_cores'] }} {{ '' -}}
-    ThreadsPerCore={{ first_host_hv['ansible_facts']['processor_threads_per_core'] }} {{ '' -}}
+    {%- if mem_spec_limit %}MemSpecLimit={{ mem_spec_limit }}{% endif %} {{ '' -}}
+    Sockets={{ slurmd_topo.get('SocketsPerBoard', first_host_hv['ansible_facts']['processor_count']) }} {{ '' -}}
+    CoresPerSocket={{ slurmd_topo.get('CoresPerSocket', first_host_hv['ansible_facts']['processor_cores']) }} {{ '' -}}
+    ThreadsPerCore={{ slurmd_topo.get('ThreadsPerCore', first_host_hv['ansible_facts']['processor_threads_per_core']) }} {{ '' -}}
     {{ nodegroup.node_params | default({}) | clip.hpc.dict2parameters }} {{ '' -}}
     {% if 'gres' in nodegroup %}Gres={{ ','.join(nodegroup.gres | map(attribute='conf')) }}{% endif %}
 
@@ -56,7 +72,7 @@ NodeName=nonesuch
 # PARTITIONS
 {% for partition in slurm_partitions %}
 PartitionName={{partition.name}} {{ '' -}}
-    Default={{ partition.get('default', 'YES') }} {{ '' -}}
+    Default={{ partition.get('default', 'NO') }} {{ '' -}}
     MaxTime={{ partition.get('maxtime', slurm_job_maxtime | default('UNLIMITED')) }} {{ '' -}}
     State=UP  {{ '' -}}
     Nodes={{ partition.get('nodegroups', [partition.name]) | map('regex_replace', '^', 'nodegroup_') | join(',') }} {{ '' -}}


### PR DESCRIPTION
Deploy a custom ansible fact that uses slurmd -C  --parameters=numa_node_as_socket to retrieve the Sockets, CoresPerSocket, RealMemory directly on the node and use this for the slurm.conf
Specify the MemSpecLimit instead of reducing RealMemory