### PR TITLE
fix[doca]: increase reboot timeout

### DIFF
--- a/roles/doca/handlers/main.yml
+++ b/roles/doca/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: Reboot machine
   ansible.builtin.reboot:
-    reboot_timeout: 600
+    reboot_timeout: 1800


### PR DESCRIPTION
surprisingly, the reboot after a fresh doca run sometimes takes more than 10 minutes, which randomly crashes image builds at the moment 