### PR TITLE
chore(agency): update .agency submodule and align conventions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".agency"]
 	path = .agency
-	url = git@github.com:vbc-it/agency.git
+	url = https://github.com/vbc-it/agency.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,17 +4,39 @@ This project uses the [agency](https://github.com/vbc-it/agency) framework for A
 
 ## Rule sources
 
-- **Organization-wide**: `.agency/rules/global/*.md` — coding standards, security policy, git conventions
-- **Ansible team**: `.agency/rules/team/ansible/*.md` — Ansible-specific standards
+- **Organization-wide**: `.agency/rules/global/*.md` — coding standards, security policy, git conventions, CI/CD, agent operating contract
+- **Ansible team**: `.agency/rules/team/ansible/*.md` — Ansible-specific standards (start from `index.md`, the always-on router; load role/playbook/collection/execution-environment/Molecule guidance only when the task needs it)
 - **Project-local**: `.github/instructions/*.instructions.md` — this project's overrides and conventions
+
+## The `.agency` submodule
+
+- Treat `.agency/` as an external, upstream-maintained repository: never edit files inside it directly.
+- `.agency` supplies generic, organization-wide and Ansible-domain-wide defaults. Project-local docs
+  (this file, `.github/instructions/*.instructions.md`) are the project-specific policy authority:
+  where a project-local rule is more specific than or differs from `.agency`, the project-local rule wins.
+- To check for or apply an update to the pinned submodule revision, use the `check-agency-update`
+  skill — it reports the available revision and requires explicit confirmation before changing
+  anything. Do not run `git submodule update --remote` (or an equivalent checkout/commit) without
+  that confirmation step.
+- Follow the agent operating contract in `.agency/rules/global/agent-behavior.md` for every change:
+  make the smallest in-scope change, run relevant validation, and treat destructive, external,
+  costly, irreversible, or scope-expanding actions as requiring explicit confirmation first.
+- For formal change reviews, apply `.agency/rules/team/ansible/review-checklist.md` (used by the
+  `ansible-review` skill) in addition to this repository's own conventions.
 
 ## Available skills
 
-Skills from `.agency/skills/` can be referenced in prompts:
-- `code-review` — structured audit against organization rules
+Skills from `.agency/skills/` can be referenced in prompts. Curated for this repo's day-to-day work:
 - `ansible-review` — review Ansible changes for safety, idempotency, and validation gaps
 - `ansible-change-plan` — plan Ansible changes by repo shape, blast radius, and validation scope
+- `code-review` — structured audit against organization rules
 - `open-pr` — open a PR with conventional format
+- `check-agency-update` — check whether the `.agency` submodule pin has an available update
+
+The full skill set (`.agency/skills/{tactical,review,generation,meta}/`) covers additional workflows
+— issue filing, security scanning/audits, README/changelog/docs generation, accessibility review,
+cross-model PR review, and agency's own maintenance skills — reference any of them by name when the
+task fits.
 
 ## Customization
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,4 +48,5 @@ Skills from `.agency/skills/` can be referenced in prompts:
 @.agency/rules/global/git-conventions.md
 @.agency/rules/global/ci-cd.md
 @.agency/rules/global/organization-context.md
+@.agency/rules/global/agent-behavior.md
 @.agency/rules/team/ansible/*.md


### PR DESCRIPTION
## Summary
- Bump the `.agency` submodule pin from `e902ec6` to `2dff060` (branch-tracked `main`; no release tag covers this range yet). Adds the cross-model evaluation workflow, agent-prompt slimming across five more agents, a workload-profile/budget model-selection layer, and v0.3.0 fixture backfill evals.
- Update `AGENTS.md` with a new "The `.agency` submodule" section documenting ownership (upstream-maintained, never edit in place), the project-local-wins-on-conflict rule, the `check-agency-update` skill for any future pin change, and the agent operating contract in `agent-behavior.md`.
- Update `CLAUDE.md` to import the previously-missing `rules/global/agent-behavior.md`.
- No project-local files (`.github/instructions/*`, `.github/copilot-instructions.md`) were touched or overwritten.

## Test plan
- [x] Verified every path referenced in the updated `AGENTS.md`/`CLAUDE.md` exists at the new submodule pin (`rules/team/ansible/index.md`, `review-checklist.md`, `rules/global/agent-behavior.md`, referenced skills).
- [x] Confirmed the submodule bump target (`2dff060`) is a real ancestor-descendant advance of `origin/main`, not an arbitrary commit.
- [ ] No Ansible task/role content changed, so `ansible-lint`/molecule were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)