### PR TITLE
chore(release): bump version to 3.5.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ clip.hpc Release Notes
 .. contents:: Topics
 
 
+v3.5.2
+======
+- beegfs: Work around GDS EXPORT_SYMBOL issue in client module and enable the workaround by default
+- beegfs: Fix non-boolean when condition in GDS workaround check on ansible-core 2.19+
+
 v3.5.1
 ======
 - rocev2: Fix DCBX task to handle non-NIC devices and ensure at least one configurable NIC

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: clip
 name: hpc
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.5.1
+version: 3.5.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
## Summary
- Bump collection version to 3.5.2 in `galaxy.yml`
- Add `v3.5.2` entry to `CHANGELOG.rst` covering the beegfs GDS EXPORT_SYMBOL workaround fixes merged since 3.5.1

## Changes included since v3.5.1
- fix(beegfs): work around GDS EXPORT_SYMBOL issue in client module
- fix(beegfs): enable GDS EXPORT_SYMBOL workaround by default
- fix(beegfs): avoid non-boolean when condition in GDS workaround check

## Test plan
- [ ] CI passes (molecule scenarios, lint)
- [ ] Verify automation hub publish succeeds after merge
- [ ] Tag `3.5.2` after merge, per repo convention (previous releases are tagged on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)